### PR TITLE
Spelling fixes for Sherlock

### DIFF
--- a/bank.zil
+++ b/bank.zil
@@ -646,7 +646,7 @@ out and gives it to you." CR>
 		       <MC-UNMAKE ,TH-GARNET ,FL-NODESC>
 		       <TELL CTHE ,CH-WIGGINS>
 		       <COND (<NOT <IN? ,CH-WIGGINS ,TH-BUTT-OF-MALMSEY>>
-			      <TELL " climbs into the empty butt of malsey,">)>
+			      <TELL " climbs into the empty butt of malmsey,">)>
 		       <TELL " gets the gem, gets out, and gives it to you."
 			     CR>
 		       <RT-UPDATE-SCORE <GETP ,TH-GARNET ,P?VALUE>>

--- a/constants.zil
+++ b/constants.zil
@@ -1034,7 +1034,7 @@ old chap.\"">
 they beat you about the head and shoulders with their shopping bags.">
 
 <CONSTANT K-GOOD-HEALTH-MSG
-" He looks suprised that you didn't try to haggle with him,
+" He looks surprised that you didn't try to haggle with him,
 says, \"Thank you, guv'nor. Enjoy it in good 'ealth,\"">
 
 <CONSTANT K-TIPSY-MSG

--- a/people.zil
+++ b/people.zil
@@ -800,7 +800,7 @@ years, his life ended on the executioner's block.\"" CR>)
 price for them.\"" CR>)
 	      (<EQUAL? .OBJ ,TH-WESTMINSTER-CLUE>
 	       <TELL
-"\"Most curious, don't you agree Watson? All thieves unintentionaly leave
+"\"Most curious, don't you agree Watson? All thieves unintentionally leave
 behind clues that are discernable to the trained eye. But it is highly
 irregular for a thief to taunt the authorities with an actual message.
 Especially one with references as obvious as this.\"" CR>)

--- a/things2.zil
+++ b/things2.zil
@@ -1057,7 +1057,7 @@ decide you're better off in the water and politely decline."  CR CR>
 <ROUTINE RT-AC-TH-OAR-1 ("OPT" (CONTEXT <>))
 	<DEBUGGING? <RT-DEBUG-OB-AC "TH-OAR-1">>
 	<COND (<==? .CONTEXT ,K-M-DESCFCN>
-	       <TELL "The oar is hopelessy jammed into the oarlock." CR>)
+	       <TELL "The oar is hopelessly jammed into the oarlock." CR>)
 	      (<MC-T? .CONTEXT>
 	       <RFALSE>)
 	      (<MC-VERB? TAKE>


### PR DESCRIPTION
These are the spelling fixes for Sherlock from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.